### PR TITLE
Set by default the sftp subsystem on FreeBSD

### DIFF
--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -2,4 +2,6 @@
 sshd_config_group: wheel
 sshd_config_mode: "0644"
 sshd_sftp_server: /usr/libexec/sftp-server
+sshd_defaults:
+  Subsystem: "sftp {{ sshd_sftp_server }}"
 sshd_os_supported: yes


### PR DESCRIPTION
Explicitly set the sftp subsystem on FreeBSD system by default, 
because ansible will need it for later runs..

Tested on: 10.1-RELEASE
Steps to reproduce: simply use the role without any additional var set
Expected result: later ansible runs should be able to complete without problems (sftp is needed by ansible to transfer files)
